### PR TITLE
Fix errors when there are no posts in database

### DIFF
--- a/resources/views/livewire/posts-overview.blade.php
+++ b/resources/views/livewire/posts-overview.blade.php
@@ -4,17 +4,24 @@
             <x-featured-post :post="$featured"></x-featured-post>
         @endif
 
-        @foreach ($posts as $post)
+        @forelse ($posts as $post)
             <div x-data="{ shown: false }" x-intersect.once="shown = true"
-                class="col-span-6 {{ ($loop->iteration <= 2 && ($page === 1 || $page === null)) ? 'lg:col-span-3' : 'lg:col-span-2' }} mb-2 group-link-underline overflow-visible font-sans rounded-lg">
+                class="col-span-6 {{ $loop->iteration <= 2 && ($page === 1 || $page === null) ? 'lg:col-span-3' : 'lg:col-span-2' }} mb-2 group-link-underline overflow-visible font-sans rounded-lg">
                 <section x-show="shown" x-transition x-transition.duration.1000ms>
                     <x-post :post="$post"></x-post>
                 </section>
             </div>
-        @endforeach
+        @empty
+            <div class="col-span-6 mb-2 overflow-visible font-sans rounded-lg group-link-underline">
+                <section x-show="shown" x-transition x-transition.duration.1000ms>
+                    No posts found.
+                </section>
+            </div>
+        @endforelse
 
-        @if (! $featured && $posts->count() < 1)
-            <h1 class="col-span-6 text-4xl text-slate-600 dark:text-slate-300 font-protogrotesk">No Posts Found. 🙁 Check back later.</h1>
+        @if (!$featured && $posts->count() < 1)
+            <h1 class="col-span-6 text-4xl text-slate-600 dark:text-slate-300 font-protogrotesk">No Posts Found. 🙁 Check
+                back later.</h1>
         @endif
     </div>
     <div class="flex justify-end w-full">


### PR DESCRIPTION
Since there had always been posts in the database, I never thought to handle the case where there were no posts. I lost all of my database, so all of my posts were gone. So there was an error when visiting the homepage because the code assumed there were posts to show. Now if no posts exists, it says so.